### PR TITLE
Fix PHP 8.4 compatibility issues

### DIFF
--- a/Block/Adminhtml/Slider/Preview.php
+++ b/Block/Adminhtml/Slider/Preview.php
@@ -21,7 +21,7 @@ class Preview extends Slider
         protected Conditions $conditions,
         protected Context $context
     ) {
-        return parent::__construct(
+        parent::__construct(
             $conditions,
             $context
         );

--- a/Block/Adminhtml/Slideshow/Preview.php
+++ b/Block/Adminhtml/Slideshow/Preview.php
@@ -22,7 +22,7 @@ class Preview extends Slideshow
         protected Context $context
     )
     {
-        return parent::__construct(
+        parent::__construct(
             $conditions,
             $context
         );

--- a/Block/Widgets/ProductWidget.php
+++ b/Block/Widgets/ProductWidget.php
@@ -20,7 +20,7 @@ use Magento\Review\Model\AppendSummaryDataFactory;
 
 class ProductWidget extends Template implements BlockInterface
 {
-    private ?LayoutInterface $productItemLayout = null;
+    protected ?LayoutInterface $productItemLayout = null;
 
     public function __construct(
         protected State $state,
@@ -155,10 +155,10 @@ class ProductWidget extends Template implements BlockInterface
             }
             $product = $productsById[(int)$rawItem['product']] ?? null;
             unset($rawItem['product']);
-            foreach ($rawItem as $key => $data) {
-                $product->setData($key, $data);
-            }
             if ($product) {
+                foreach ($rawItem as $key => $data) {
+                    $product->setData($key, $data);
+                }
                 $products[] = $product;
             }
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.4.5
+### Fixed
+- Fix null dereference on product loading in ProductWidget
+- Remove invalid return statement from constructors in Slider/Preview and Slideshow/Preview
+- Change readonly private to protected readonly in RegisterModuleForHyvaConfig
+
 ## 1.4.4
 ### Updated
 - Fix dotnav for slider/product-slider widgets on mobile

--- a/Observer/RegisterModuleForHyvaConfig.php
+++ b/Observer/RegisterModuleForHyvaConfig.php
@@ -13,7 +13,7 @@ class RegisterModuleForHyvaConfig implements ObserverInterface
      * @param ComponentRegistrar $componentRegistrar
      */
     public function __construct(
-        readonly private ComponentRegistrar $componentRegistrar
+        protected readonly ComponentRegistrar $componentRegistrar
     ) {}
 
     /**


### PR DESCRIPTION
## Summary
- Fix null dereference on product loading in ProductWidget
- Remove invalid return statement from constructors in Slider/Preview and Slideshow/Preview
- Change readonly private to protected readonly in RegisterModuleForHyvaConfig

## Changes
- **ProductWidget.php**: moved setData calls inside null check to prevent fatal error
- **Slider/Preview.php, Slideshow/Preview.php**: removed return from parent::__construct() calls
- **RegisterModuleForHyvaConfig.php**: changed readonly private to protected readonly for extensibility
- **CHANGELOG.md**: added 1.4.5 entry

## Suggested release
This could be tagged as 1.4.5 (patch release).