### PR TITLE
PHP 8.4 and 8.5 compatibility

### DIFF
--- a/Block/Adminhtml/Grid/Preview.php
+++ b/Block/Adminhtml/Grid/Preview.php
@@ -8,10 +8,10 @@ use Magento\Framework\View\Element\Template\Context;
 use Magento\Store\Model\App\Emulation;
 use Magento\Widget\Helper\Conditions;
 use MageOS\Widgetkit\Block\Widgets\Grid;
+use Magento\Framework\Exception\LocalizedException;
 
 class Preview extends Grid
 {
-
     /**
      * @param Emulation $emulation
      * @param Conditions $conditions
@@ -25,6 +25,10 @@ class Preview extends Grid
         parent::__construct($conditions, $context);
     }
 
+    /**
+     * @return string
+     * @throws LocalizedException
+     */
     public function renderMainTemplate(): string
     {
         $this->emulation->startEnvironmentEmulation(1, Area::AREA_FRONTEND, true);

--- a/Block/Widgets/ProductWidget.php
+++ b/Block/Widgets/ProductWidget.php
@@ -110,10 +110,10 @@ class ProductWidget extends Template implements BlockInterface
 
     /**
      * @param Template $block
-     * @param $repeatableFieldKey
+     * @param string $repeatableFieldKey
      * @return array
      */
-    public function loadProducts(Template $block, $repeatableFieldKey): array
+    public function loadProducts(Template $block, string $repeatableFieldKey): array
     {
         $rawItems = $block->getRepeatableField($repeatableFieldKey);
         if (empty($rawItems)) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.4.6 - 2026-04-21
+### Fixed
+- PHP 8.4 and 8.5 compatibility: add missing parameter type in ProductWidget::loadProducts, add explicit void return type on Observer::execute, guard against null module path before substr(), add missing @throws PHPDoc on Adminhtml\Grid\Preview::renderMainTemplate
+
 ## 1.4.5
 ### Fixed
 - Fix null dereference on product loading in ProductWidget

--- a/Observer/RegisterModuleForHyvaConfig.php
+++ b/Observer/RegisterModuleForHyvaConfig.php
@@ -20,7 +20,7 @@ class RegisterModuleForHyvaConfig implements ObserverInterface
      * @param Observer $event
      * @return void
      */
-    public function execute(Observer $event)
+    public function execute(Observer $event): void
     {
         $config = $event->getData('config');
         $extensions = $config->hasData('extensions') ? $config->getData('extensions') : [];
@@ -28,8 +28,10 @@ class RegisterModuleForHyvaConfig implements ObserverInterface
         $moduleName = implode('_', array_slice(explode('\\', __CLASS__), 0, 2));
 
         $path = $this->componentRegistrar->getPath(ComponentRegistrar::MODULE, $moduleName);
+        if ($path === null) {
+            return;
+        }
 
-        // Only use the path relative to the Magento base dir
         $extensions[] = ['src' => substr($path, strlen(BP) + 1)];
 
         $config->setData('extensions', $extensions);


### PR DESCRIPTION
## Summary

This PR applies small but necessary changes to make the module fully compatible with PHP 8.4 and PHP 8.5.

### Changes

- **Block/Widgets/ProductWidget.php**: add explicit `string` type hint to the `$repeatableFieldKey` parameter of `loadProducts()`. PHP 8.4 strict typing cleanup; the parameter is always used as a string key.
- **Observer/RegisterModuleForHyvaConfig.php**: add explicit `: void` return type on `execute()` (cleaner PHP 8.x signature), and guard against a possible `null` return from `ComponentRegistrar::getPath()` before passing it to `substr()`. PHP 8.1+ deprecates passing `null` to string functions, which becomes a TypeError in later versions.
- **Block/Adminhtml/Grid/Preview.php**: add the missing `@throws LocalizedException` PHPDoc on `renderMainTemplate()` (for consistency with sibling Preview classes) and import the exception via `use`.
- **CHANGELOG.md**: add `1.4.6` entry dated 2026-04-21.

### Compatibility

No behavioural change. Still compatible with PHP 8.1+ (`composer.json` constraint unchanged). Safe to run on PHP 8.4 and PHP 8.5 without deprecation notices.

### Suggested release

Patch release `1.4.6`.

cc @rhoerr
